### PR TITLE
Fix line overflows

### DIFF
--- a/presenterm_export/capture.py
+++ b/presenterm_export/capture.py
@@ -29,6 +29,7 @@ def capture_slides(
     size = os.get_terminal_size()
     tmux_server = libtmux.Server()
     command = " ".join([f"'{arg}'" for arg in args])
+    print(f"Running {command}")
     session = tmux_server.new_session(
         session_name="presenterm-capturer",
         attach=False,

--- a/presenterm_export/cli.py
+++ b/presenterm_export/cli.py
@@ -6,6 +6,7 @@ from tempfile import TemporaryDirectory
 from dataclasses import dataclass
 from typing import List, Dict
 from dataclass_wizard import JSONWizard
+import libtmux
 
 from presenterm_export.capture import capture_slides
 from presenterm_export.html import FONT_SIZE_WIDTH, slides_to_html
@@ -29,6 +30,8 @@ class PresentationPath:
 
 
 def run(args, metadata: PresentationMetadata):
+    print(f"tmux version: {libtmux.common.get_version()}")
+
     output_directory = TemporaryDirectory()
     print(f"Writing temporary files into {output_directory.name}")
 

--- a/presenterm_export/pdf.py
+++ b/presenterm_export/pdf.py
@@ -36,6 +36,7 @@ def generate_pdf(input_html: str, dimensions: PresentationSize, options: PdfOpti
         body {{
             margin: 0;
             font-size: {font_size}px;
+            line-height: {line_height}px;
             background-color: {background_color};
             width: {width}px;
         }}

--- a/presenterm_export/pdf.py
+++ b/presenterm_export/pdf.py
@@ -1,3 +1,4 @@
+import platform
 from dataclasses import dataclass
 import weasyprint
 
@@ -24,6 +25,10 @@ def generate_pdf(input_html: str, dimensions: PresentationSize, options: PdfOpti
     line_height = options.line_height
     height = dimensions.rows * line_height
     width = dimensions.columns * font_size * FONT_SIZE_WIDTH
+    body_line_height = f"line-height: {line_height}px;"
+    # The line above fixes an issue in fedora but causes the issue in macOS...
+    if platform.system() == "Darwin":
+        body_line_height = ""
     styles = f"""
         pre {{
             margin: 0;
@@ -36,7 +41,7 @@ def generate_pdf(input_html: str, dimensions: PresentationSize, options: PdfOpti
         body {{
             margin: 0;
             font-size: {font_size}px;
-            line-height: {line_height}px;
+            {body_line_height}
             background-color: {background_color};
             width: {width}px;
         }}


### PR DESCRIPTION
This fixes an issue where lines appear larger than they should, seemingly because the line height was only set on a line basis but not in the body. This seems to happen on fedora 39, it's not clear why only in this environment this happens but :shrug:.

Fixes #4