### PR TITLE
fix: bump weasyprint to non broken pydyf dependent one

### DIFF
--- a/presenterm_export/capture.py
+++ b/presenterm_export/capture.py
@@ -17,9 +17,7 @@ class Presentation:
     size: PresentationSize
 
 
-def capture_slides(
-    args: List[str], presentation_path: str, commands: List[Dict[str, str]]
-):
+def capture_slides(args: List[str], commands: List[Dict[str, str]]):
     """
     Capture the slides for a presentation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ maintainers = [
 dependencies = [
   "ansi2html==1.8.0",
   "libtmux==0.23.2",
-  "weasyprint==60.1.0",
+  "weasyprint==62.3.0",
   "dataclass-wizard==0.22.2"
 ]
 


### PR DESCRIPTION
presenterm-export installs are currently failing because:

* pydyf (dependency of weasyprint) changed the interface of the `Pdf` class [here](https://github.com/CourtBouillon/pydyf/commit/15a4625f9f010e42b43643b55514b03823c601d2#diff-0a244f4a141e0ef3468995e4a9e2ddb0829a0d9b37926bcbf624182e9d10f216R470).
* This is available only in pydyf 0.11.0 (latest version).
* However, weasyprint until recently only claimed it needed pydyf >= 0.10 (see [here](https://github.com/Kozea/WeasyPrint/commit/dd7cee28a04b7c1afca16bc679eb20526d30aaa4#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L15)).
* This means if you install an older version of weasyprint like presenterm requires (e.g. 60.1.0) it will pull weasyprint 60.1.0 but because that one has no upper bound on which version of pydyf it needs, it will pull 0.11.0, but this version is incompatible with weasyprint 60.1.0.

This bumps weasyprint 60.1.0 to the latest version, which is not broken. The issue on their end is https://github.com/Kozea/WeasyPrint/issues/2200.

Fixes #8