### PR TITLE
fix: don't overflow PDF pages

### DIFF
--- a/presenterm_export/capture.py
+++ b/presenterm_export/capture.py
@@ -18,7 +18,7 @@ class Presentation:
     size: PresentationSize
 
 
-def capture_slides(args: List[str], commands: List[Dict[str, str]]):
+def capture_slides(args: List[str], commands: List[Dict[str, str]]) -> Presentation:
     """
     Capture the slides for a presentation.
 

--- a/presenterm_export/cli.py
+++ b/presenterm_export/cli.py
@@ -51,7 +51,7 @@ def run(args, metadata: PresentationMetadata):
         raise Exception("could not capture any slides")
 
     print("Converting slides to HTML...")
-    presentation_html = slides_to_html(presentation.slides)
+    presentation_html = slides_to_html(presentation.slides, presentation.size.rows)
     if args.emit_intermediate:
         persist(presentation_html, input_path.replace_extension("pre.html"))
 

--- a/presenterm_export/pdf.py
+++ b/presenterm_export/pdf.py
@@ -32,6 +32,7 @@ def generate_pdf(input_html: str, dimensions: PresentationSize, options: PdfOpti
     styles = f"""
         pre {{
             margin: 0;
+            padding: 0;
         }}
 
         span {{
@@ -47,7 +48,6 @@ def generate_pdf(input_html: str, dimensions: PresentationSize, options: PdfOpti
         }}
 
         .content-line {{
-            display: inline-block;
             line-height: {line_height}px; 
             margin: 0px;
             width: {width}px;
@@ -61,5 +61,8 @@ def generate_pdf(input_html: str, dimensions: PresentationSize, options: PdfOpti
 """
     css = weasyprint.CSS(string=styles)
     html.write_pdf(
-        target=options.output_path, stylesheets=[css], presentational_hints=True
+        target=options.output_path,
+        stylesheets=[css],
+        presentational_hints=True,
+        uncompressed_pdf=True,
     )


### PR DESCRIPTION
This addresses the PDF page overflow issue. It's unclear exactly what was going on but the use of `pre` seemed to be causing issues so I re-wrote the structure of the intermediate HTML such that there's a `<div><pre>` per line. This seems to fix the issue and also makes the HTML a lot easier to debug.

Hopefully fixes #6